### PR TITLE
feat(azuiv2): add azui-input-code component and validation directive

### DIFF
--- a/projects/azuiv2/src/lib/components/azui-input-code/azui-input-code.component.html
+++ b/projects/azuiv2/src/lib/components/azui-input-code/azui-input-code.component.html
@@ -1,0 +1,18 @@
+<div class="flex gap-8">
+    <azui-input-group *ngFor="let e of [].constructor(length); let i = index" 
+        [azStyle]="{height: height , width: width}"
+        [ngStyle]="{'margin-right': ((i+1)%divideEach === 0 && i !== length-1) ? '24px' : ''}"
+        [ngClass]="{'br-8 border-danger-hard o-hidden': !codigoValido}"
+        [hasError]="!codigoValido"
+    >
+        <input #inputText type="text" azui-input maxlength="1"
+        (keyup)="onWrite(i,inputText.value,$event)"
+        (keydown.backspace)="onBackSpace(i)"
+        validateRegexDirective
+        [regex]="patronValidacion"
+        [ngClass]="{'input-text-error': !codigoValido}"
+        class="text-center"
+        [disabled]="isDisabled"
+        />
+    </azui-input-group>
+</div>

--- a/projects/azuiv2/src/lib/components/azui-input-code/azui-input-code.component.scss
+++ b/projects/azuiv2/src/lib/components/azui-input-code/azui-input-code.component.scss
@@ -1,0 +1,68 @@
+
+azui-input-group{
+    overflow: hidden;
+
+}
+input{
+    font-size: 34px;
+    font-weight: 500;
+    padding-left: 0;
+    padding-right: 0;
+    caret-color: transparent;
+}
+
+input:focus{
+    border-bottom: 3px solid var(--color-primary-5);
+}
+
+.input-error{
+    border: 3px solid var(--color-danger-soft);
+    border-radius: 16px;
+    animation: 0.4s shake ease-in-out;
+}
+.input-text-error{
+    color: var(--color-danger-hard);
+    pointer-events: none;
+}
+
+
+.type-text{
+    animation: 0.3s downText ease-in;
+}
+
+.type-text-slow{
+    animation: 0.5s downText ease-in;
+}
+
+@keyframes downText {
+    from {
+        opacity: 0;
+        transform: translate3d(0, -100%, 0);
+    }
+    
+    to {
+        opacity: 1;
+        transform: translate3d(0, 0, 0);
+    }
+}
+
+@keyframes shake{
+    0%{
+        transform: translateX(0);
+    }
+    25%{
+        transform: translateX(-5px);
+    }
+    50%{
+        transform: translateX(5px);
+    }
+    75%{
+        transform: translateX(-5px);
+    }
+    100%{
+        transform: translateX(0);
+    }
+}
+
+  
+

--- a/projects/azuiv2/src/lib/components/azui-input-code/azui-input-code.component.ts
+++ b/projects/azuiv2/src/lib/components/azui-input-code/azui-input-code.component.ts
@@ -1,0 +1,161 @@
+import { CommonModule } from '@angular/common';
+import { Component, forwardRef, HostListener, Input, QueryList, ViewChildren } from '@angular/core';
+import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
+import { AzuiInputGroupComponent } from '../azui-input/azui-input-group/azui-input-group.component';
+import { AzuiInputModule } from '../azui-input/azui-input.module';
+import { ValidateRegexDirective } from '../../directives/azui-input-code/validate-regex.directive';
+
+@Component({
+    selector: 'azui-input-code',
+    standalone: true,
+    imports: [
+        CommonModule,
+        AzuiInputModule,
+        ValidateRegexDirective
+    ],
+    providers: [
+        {
+            provide: NG_VALUE_ACCESSOR,
+            useExisting: forwardRef(() => AzuiInputCodeComponent),
+            multi: true
+
+        },
+    ],
+    templateUrl: './azui-input-code.component.html',
+    styleUrls: ['./azui-input-code.component.scss'],
+})
+
+export class AzuiInputCodeComponent implements ControlValueAccessor {
+
+    @ViewChildren(AzuiInputGroupComponent)
+    inputs!: QueryList<AzuiInputGroupComponent>;
+    @Input() length!: number;
+    @Input() patronValidacion: 'alfanumerico' | 'numerico' = 'alfanumerico';
+    @Input() divideEach = 0;
+    @Input() codigoValido = true;
+    @Input() width = '52px';
+    @Input() height = '70px';
+
+
+    public isDisabled: boolean = false;
+    public value: string = '';
+    public onChangeIs?: (value: string) => {};
+    public onTouchedIs?: () => void;
+
+    @HostListener('paste', ['$event'])
+    onPaste(e: ClipboardEvent): void {
+        const items = e.clipboardData?.getData('text');
+        const regex = new RegExp(ValidateRegexDirective.regexMap[this.patronValidacion]);
+        if (typeof items !== 'string' || !regex.test(items)) return;
+        e.preventDefault();
+        requestAnimationFrame(() => {
+            this.writeValue(items);
+        });
+    }
+
+    writeValue(value: string): void {
+        this.value = value;
+        this.setAllValues(this.value);
+    }
+    registerOnChange(fn: any): void {
+        this.onChangeIs = fn;
+    }
+    registerOnTouched(fn: any): void {
+        this.onTouchedIs = fn;
+    }
+    setDisabledState?(isDisabled: boolean): void {
+        this.isDisabled = isDisabled;
+    }
+
+    ngAfterViewInit(): void {
+        this.inputs.toArray()[0].input!.elementRef.nativeElement.select();
+        this.inputs.toArray()[0].input!.elementRef.nativeElement.focus();
+        this.inputs.toArray().slice(1).forEach(input => input.input!.elementRef.nativeElement.disabled = true);
+        this.setAllValues(this.value);
+    }
+
+    onWrite(i: number, valor: string, event: KeyboardEvent): void {
+
+        if (event.key !== 'Backspace') {
+            this.value = this.getAllValues();
+            this.onChangeIs?.(this.value);
+            if (i !== this.length - 1 && valor.length === 1) {
+                this.inputs.toArray()[i].input!.elementRef.nativeElement.classList.add('type-text');
+                this.inputs.toArray()[i + 1].input!.elementRef.nativeElement.disabled = false;
+                this.inputs.toArray()[i + 1].input!.elementRef.nativeElement.focus();
+                this.inputs.toArray().slice(i + 2).forEach(input => input.input!.elementRef.nativeElement.disabled = true);
+                this.inputs.toArray().slice(0, i + 1).forEach(input => input.input!.elementRef.nativeElement.disabled = true);
+            }
+        }
+    }
+
+    onBackSpace(i: number): void {
+        let remainingInputs = this.getRemainingInputs();
+        this.value = this.getAllValues();
+        this.onChangeIs?.(this.value);
+        if (i > 0) {
+            this.inputs.toArray()[i].input!.elementRef.nativeElement.value = '';
+            this.inputs.toArray()[i].input!.elementRef.nativeElement.classList.remove('type-text');
+            this.inputs.toArray()[i - 1].input!.elementRef.nativeElement.disabled = false;
+            this.inputs.toArray()[i - 1].input!.elementRef.nativeElement.focus();
+            this.inputs.toArray().slice(i).forEach(input => input.input!.elementRef.nativeElement.disabled = true);
+        }
+        if (i == 0 && remainingInputs === this.length) {
+            this.inputs.toArray()[i].input!.elementRef.nativeElement.focus();
+        }
+    }
+
+
+
+
+    getRemainingInputs(): number {
+        return this.inputs.toArray().filter(input => input.input!.elementRef.nativeElement.value == '').length
+    }
+
+
+    getAllValues(): string {
+        return this.inputs.toArray().map(input => input.input!.elementRef.nativeElement.value).join('');
+    }
+
+    setAllValues(value: string | null | undefined): void {
+        const values = (value ?? '').split('');
+        if (values.length === this.length && this.inputs) {
+            this.inputs.toArray().forEach((input, i) => {
+                input.input!.elementRef.nativeElement.value = values[i];
+                if (i !== this.length) {
+                    input.input!.elementRef.nativeElement.classList.add('type-text-slow');
+                }
+            });
+            this.inputs.toArray()[this.length - 1].input!.elementRef.nativeElement.disabled = false;
+            this.inputs.toArray()[this.length - 1].input!.elementRef.nativeElement.focus();
+            this.inputs.toArray().slice(0, this.length - 1).forEach(input => input.input!.elementRef.nativeElement.disabled = true);
+        } else if (this.inputs && values.length === 0) {
+            this.inputs.toArray().forEach(input => {
+                input.input!.elementRef.nativeElement.value = '';
+                input.input!.elementRef.nativeElement.classList.remove('type-text-slow');
+            });
+            this.inputs.toArray()[0].input!.elementRef.nativeElement.focus();
+            this.inputs.toArray().slice(1).forEach(input => input.input!.elementRef.nativeElement.disabled = true);
+        } else if (this.inputs && values.length < this.length) {
+            this.inputs.toArray().forEach((input, i) => {
+                input.input!.elementRef.nativeElement.value = values[i] || '';
+                if (values[i]) {
+                    input.input!.elementRef.nativeElement.classList.add('type-text-slow');
+                } else {
+                    input.input!.elementRef.nativeElement.classList.remove('type-text-slow');
+                }
+            });
+            this.inputs.toArray()[0].input!.elementRef.nativeElement.disabled = true;
+            this.inputs.toArray()[values.length].input!.elementRef.nativeElement.disabled = false;
+            this.inputs.toArray()[values.length].input!.elementRef.nativeElement.focus();
+        }
+    }
+
+
+
+
+
+
+
+
+}

--- a/projects/azuiv2/src/lib/components/azui-input/azui-input-group/azui-input-group.component.html
+++ b/projects/azuiv2/src/lib/components/azui-input/azui-input-group/azui-input-group.component.html
@@ -8,6 +8,7 @@
     'az-input-group__value--disabled': isDisabled && !label,
     'az-input-group__label--disabled': isDisabled && label,
     'az-input-group__error': !isDisabled && hasError,
+    'az-input-group__error--disabled': isDisabled && hasError,
   }"
 >
   <ng-container *ngIf="prefixRef">

--- a/projects/azuiv2/src/lib/components/azui-input/azui-input-group/azui-input-group.component.ts
+++ b/projects/azuiv2/src/lib/components/azui-input/azui-input-group/azui-input-group.component.ts
@@ -39,6 +39,7 @@ export class AzuiInputGroupComponent implements OnInit, OnDestroy {
   hasFocus = false;
   observer?: MutationObserver;
 
+  @Input()
   hasError = false;
 
   focusEvent = () => {

--- a/projects/azuiv2/src/lib/directives/azui-input-code/validate-regex.directive.ts
+++ b/projects/azuiv2/src/lib/directives/azui-input-code/validate-regex.directive.ts
@@ -1,0 +1,58 @@
+import { Directive, ElementRef, HostListener, Input } from '@angular/core';
+
+@Directive({
+  selector: '[validateRegexDirective]',
+  standalone: true,
+})
+export class ValidateRegexDirective {
+  @Input() regex: 'numerico' | 'alfanumerico' = 'numerico'; 
+  private static forbiddenKeys = [
+    'ArrowLeft',
+    'ArrowRight',
+    'ArrowUp',
+    'ArrowDown',
+    'Backspace',
+    'Tab',
+    'Alt',
+    'Shift',
+    'Control',
+    'Enter',
+    'Delete',
+    'Meta',
+  ];
+
+  public static regexMap = {
+    numerico: '^[0-9]*$',
+    alfanumerico: '^[a-zA-Z0-9]*$',
+  };
+
+  constructor(
+    private readonly _el: ElementRef,
+  ) {}
+
+  @HostListener('keydown', ['$event']) onKeyDown(event: any) {
+    if (
+      (event.keyCode == 67 && event.ctrlKey === true) ||
+      (event.keyCode == 86 && event.ctrlKey === true) ||
+      (event.keyCode == 88 && event.ctrlKey === true)
+    ) {
+      return;
+    }
+
+    let value: string = event.target.value + event.key;
+
+    if (ValidateRegexDirective.forbiddenKeys.includes(event.key)) return;
+
+    let re = new RegExp(ValidateRegexDirective.regexMap[this.regex]);
+
+    if (!re.test(value)) event.preventDefault();
+  }
+
+  @HostListener('keyup', ['$event']) onKeyUp(event: any) {
+    let value: string = event.target.value;
+    const valueReplaced = value.replace(new RegExp(`[^${ValidateRegexDirective.regexMap[this.regex]}]`, 'g'), '');
+
+    (this._el.nativeElement as HTMLInputElement).value = valueReplaced;
+    event.preventDefault();
+  }
+}

--- a/projects/azuiv2/src/public-api.ts
+++ b/projects/azuiv2/src/public-api.ts
@@ -34,3 +34,6 @@ export * from './lib/components/azui-input-number/azui-input-number.component';
 export * from './lib/components/azui-message/azui-message.component';
 
 export * from './lib/components/azui-modal/azui-modal.component';
+
+
+export * from './lib/components/azui-input-code/azui-input-code.component';

--- a/projects/azuiv2/src/styles/3-Atoms/input.scss
+++ b/projects/azuiv2/src/styles/3-Atoms/input.scss
@@ -96,3 +96,11 @@ input[disabled] {
 input[disabled]::placeholder {
   color: map-get($colors, primary-2);
 }
+
+.az-input-group__error--disabled {
+  border: none;
+  border-radius: 8px;
+}
+.az-input-group__error--disabled > span:first-child {
+  color: map-get($colors, primary-2);
+}

--- a/projects/azuiv2/src/styles/general.scss
+++ b/projects/azuiv2/src/styles/general.scss
@@ -16,6 +16,7 @@
   --color-primary-5: #{map-get($colors, primary-5)};
   --color-primary-6: #{map-get($colors, primary-6)};
   --color-danger-hard: #{map-get($colors, danger-hard)};
+  --color-danger-soft: #{map-get($colors, danger-soft)};
 }
 
 // SET UP

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -106,6 +106,7 @@
       </azui-input-group>
     </azui-error>
 
+    
     <azui-input-group
       [prefixRef]="prefixbuscar"
       label="¿Qué estás buscando?"
@@ -119,6 +120,28 @@
         type="text"
       />
     </azui-input-group>
+
+    <azui-input-code
+    patronValidacion="alfanumerico"
+    [length]="6"
+    [divideEach]="3"
+    [codigoValido]="false"
+    width="52px"
+    height="70px"
+    />
+
+    <azui-divider></azui-divider>
+
+
+    <azui-input-code
+    patronValidacion="alfanumerico"
+    [length]="6"
+    [divideEach]="3"
+    [codigoValido]="true"
+    width="52px"
+    height="70px"
+    />
+
 
     <ng-template #prefixbuscar>
       <span azui-icons name="lupa"></span>

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -16,9 +16,11 @@ import {
   AzuiInputNumberComponent,
   AzuiMessageComponent,
   AzuiModalComponent,
+  AzuiInputCodeComponent,
 } from 'dist/azuiv2';
 import { HttpClientModule } from '@angular/common/http';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+
 
 @NgModule({
   declarations: [AppComponent],
@@ -32,6 +34,7 @@ import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
     AzuiDividerComponent,
     AzuiErrorComponent,
     AzuiIcons,
+    AzuiInputCodeComponent,
     AzuiInputModule,
     AzuiTextareaComponent,
     AzuiFileUploadModule,


### PR DESCRIPTION
## Descripción

Este pull request añade el componente `azui-input-code`, diseñado para la validación de códigos de doble autenticación o códigos de confirmación.

### Tipo de cambio

- **Feature** (azuiv2)

### ¿Cómo se han probado estos cambios?

Es necesario volver a compilar **azuiv2** para probar los cambios de forma efectiva.

### Lista de verificación

- [x] Todas las pruebas pasan localmente.

## Comentarios adicionales

- Se han añadido nuevos estilos en `projects/azuiv2/src/styles/3-Atoms/input.scss` para gestionar el estado de un input desactivado y con error. Este estado es utilizado por el componente `azui-input-code` cuando el código ingresado no es válido.
  
- Se ha incorporado una nueva directiva en `projects/azuiv2/src/lib/directives/azui-input-code/validate-regex.directive.ts` para validar si los valores introducidos cumplen con un patrón establecido (numérico o alfanumérico).

- Se ha añadido el decorador `@Input` a la propiedad `hasError` del componente `azui-input-group`, lo que permite el control manual de esta propiedad desde el componente `azui-input-code` cuando hay errores en la validación del código.
